### PR TITLE
Fix for attribute error

### DIFF
--- a/django_sphinx_db/backend/sphinx/compiler.py
+++ b/django_sphinx_db/backend/sphinx/compiler.py
@@ -2,6 +2,9 @@ from django.db.models.sql import compiler
 from django.db.models.sql.where import WhereNode
 
 
+SQLCompiler = compiler.SQLCompiler
+
+
 class SphinxWhereNode(WhereNode):
     def sql_for_columns(self, data, qn, connection):
         table_alias, name, db_type = data


### PR DESCRIPTION
Assign SQLCompiler from the compiler object since Django assumes there
will be a SQLCompiler class within the backend compiler.  This should
prevent errors along the lines of:
    AttributeError: 'module' object has no attribute 'SQLCompiler'
