### PR TITLE
Use compiler consistently

### DIFF
--- a/django_sphinx_db/backend/models.py
+++ b/django_sphinx_db/backend/models.py
@@ -4,8 +4,6 @@ from django.db.models.query import QuerySet
 from django_sphinx_db.backend.sphinx.compiler import SphinxWhereNode
 
 class SphinxQuery(Query):
-    compiler = 'SphinxQLCompiler'
-
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('where', SphinxWhereNode)
         super(SphinxQuery, self).__init__(*args, **kwargs)

--- a/django_sphinx_db/backend/sphinx/compiler.py
+++ b/django_sphinx_db/backend/sphinx/compiler.py
@@ -2,9 +2,6 @@ from django.db.models.sql import compiler
 from django.db.models.sql.where import WhereNode
 
 
-SQLCompiler = compiler.SQLCompiler
-
-
 class SphinxWhereNode(WhereNode):
     def sql_for_columns(self, data, qn, connection):
         table_alias, name, db_type = data
@@ -66,6 +63,9 @@ class SphinxQLCompiler(compiler.SQLCompiler):
         # This is to remove the `` backticks from identifiers.
         # http://sphinxsearch.com/bugs/view.php?id=1150
         return name
+
+# Set SQLCompiler appropriately, so queries will use the correct compiler.
+SQLCompiler = SphinxQLCompiler
 
 
 class SQLInsertCompiler(compiler.SQLInsertCompiler, SphinxQLCompiler):


### PR DESCRIPTION
Have SphinxQuery use the default compiler from Query ('SQLCompiler')
while setting SQLCompiler to SphinxQLCompiler.  This should fix unit
tests that report:
    AttributeError: 'module' object has no attribute 'SphinxQLCompiler'
