### PR TITLE
Use model._meta.db_table in syncsphinx command

### DIFF
--- a/django_sphinx_db/management/commands/syncsphinx.py
+++ b/django_sphinx_db/management/commands/syncsphinx.py
@@ -103,6 +103,6 @@ class Command(BaseCommand):
                 ))
             print CONF_TEMPLATE % dict(
                 fields = '\n\t'.join(field_conf),
-                index_name = model.__name__.lower(),
+                index_name = model._meta.db_table,
                 directory = kwargs.get('directory')
             )


### PR DESCRIPTION
Currently, the `syncsphinx` management command ignores the `db_table` model meta configuration. But even if no `db_table` meta option is set – if I understood the code correctly – Django queries the table called `model._meta.db_table`, and not `model.__name__.lower()`.

This small commit fixes this in the `syncsphinx` command.
