### PR TITLE
Removed min_infix_len from syncsphinx

### DIFF
--- a/django_sphinx_db/management/commands/syncsphinx.py
+++ b/django_sphinx_db/management/commands/syncsphinx.py
@@ -17,7 +17,6 @@ index %(index_name)s
 	# Options:
 	type			= rt
 	path			= %(directory)s/%(index_name)s
-	min_infix_len		= 3
 	enable_star		= 1
 
 	# Fields:


### PR DESCRIPTION
RT indexes do not support infixes yet.
